### PR TITLE
Add Japanese homepage layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cometrue Strategy | HP</title>
+    <meta
+      name="description"
+      content="Cometrue Strategyのホームページ。企業価値を高める戦略立案と実行支援を提供します。"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="nav">
+        <div class="logo">Cometrue Strategy</div>
+        <ul class="nav-links">
+          <li><a href="#about">事業紹介</a></li>
+          <li><a href="#services">サービス</a></li>
+          <li><a href="#cases">実績</a></li>
+          <li><a href="#contact">お問い合わせ</a></li>
+        </ul>
+        <a class="nav-cta" href="#contact">資料請求</a>
+      </nav>
+      <div class="hero-content">
+        <p class="eyebrow">Strategy & Growth Partner</p>
+        <h1>未来をつくる、<br />実行力ある戦略を。</h1>
+        <p class="hero-copy">
+          Cometrue Strategyは、企業の課題を起点に、
+          データと現場視点を融合した戦略立案・実行支援を行います。
+        </p>
+        <div class="hero-actions">
+          <a class="button primary" href="#contact">無料相談を申し込む</a>
+          <a class="button ghost" href="#services">サービスを見る</a>
+        </div>
+        <div class="hero-highlights">
+          <div>
+            <span class="highlight-number">120+</span>
+            <span class="highlight-label">支援プロジェクト</span>
+          </div>
+          <div>
+            <span class="highlight-number">93%</span>
+            <span class="highlight-label">継続率</span>
+          </div>
+          <div>
+            <span class="highlight-number">8週</span>
+            <span class="highlight-label">最短戦略設計</span>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="about" class="section">
+        <div class="section-header">
+          <p class="eyebrow">About</p>
+          <h2>戦略と実行の距離をゼロに。</h2>
+        </div>
+        <div class="grid two">
+          <div>
+            <p>
+              私たちは、経営・事業・ブランドのすべてを横断し、
+              "成果に直結する戦略"を設計します。リサーチからKPI設計、
+              現場展開まで伴走し、意思決定のスピードを高めます。
+            </p>
+            <ul class="check-list">
+              <li>経営課題を言語化するデジタル診断</li>
+              <li>データ×現場知見による仮説構築</li>
+              <li>実行計画とチーム設計の同時支援</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>ミッション</h3>
+            <p>
+              「可能性を、確かな結果へ。」
+              企業の未来を描き、確かな成果へ導く伴走者として
+              価値創出にコミットします。
+            </p>
+            <div class="card-meta">
+              <span>拠点: 東京・大阪</span>
+              <span>対応領域: 国内/海外</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="services" class="section alt">
+        <div class="section-header">
+          <p class="eyebrow">Services</p>
+          <h2>課題フェーズに合わせた支援メニュー</h2>
+        </div>
+        <div class="grid three">
+          <article class="service">
+            <h3>戦略策定</h3>
+            <p>市場・顧客・競合を分析し、事業戦略と成長シナリオを設計。</p>
+            <span>期間: 4〜8週</span>
+          </article>
+          <article class="service">
+            <h3>組織・KPI設計</h3>
+            <p>実行可能なKPIと組織設計で、現場の推進力を可視化。</p>
+            <span>期間: 4〜6週</span>
+          </article>
+          <article class="service">
+            <h3>実行伴走</h3>
+            <p>リリース後も伴走し、定着までハンズオンで支援。</p>
+            <span>期間: 3〜12ヶ月</span>
+          </article>
+        </div>
+      </section>
+
+      <section id="cases" class="section">
+        <div class="section-header">
+          <p class="eyebrow">Cases</p>
+          <h2>成果につながる支援実績</h2>
+        </div>
+        <div class="grid two">
+          <div class="case">
+            <h3>成長率150%を実現したB2B事業再構築</h3>
+            <p>
+              事業ポートフォリオを再設計し、セールスとマーケの連携を強化。
+              6ヶ月でリード獲得数が2.5倍に。
+            </p>
+          </div>
+          <div class="case">
+            <h3>地方メーカーの海外展開支援</h3>
+            <p>
+              競合分析とブランド再定義により、海外代理店の獲得数が3倍に。
+              1年で海外売上構成比が25%へ。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section alt">
+        <div class="section-header">
+          <p class="eyebrow">Contact</p>
+          <h2>まずはお気軽にご相談ください</h2>
+        </div>
+        <div class="contact">
+          <div>
+            <p>
+              初回のご相談は無料です。現状の課題や目指す姿をお聞かせください。
+              2営業日以内に担当よりご連絡いたします。
+            </p>
+            <div class="contact-details">
+              <span>Mail: hello@cometrue.co.jp</span>
+              <span>Tel: 03-1234-5678</span>
+              <span>受付時間: 平日 9:30-18:00</span>
+            </div>
+          </div>
+          <form class="contact-form">
+            <label>
+              会社名
+              <input type="text" placeholder="株式会社〇〇" />
+            </label>
+            <label>
+              ご担当者名
+              <input type="text" placeholder="山田 太郎" />
+            </label>
+            <label>
+              メールアドレス
+              <input type="email" placeholder="example@company.jp" />
+            </label>
+            <label>
+              ご相談内容
+              <textarea rows="4" placeholder="課題やご希望をお聞かせください"></textarea>
+            </label>
+            <button type="submit" class="button primary">送信する</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <div class="logo">Cometrue Strategy</div>
+        <p>戦略と実行で、成長を加速する。</p>
+      </div>
+      <div class="footer-links">
+        <a href="#about">事業紹介</a>
+        <a href="#services">サービス</a>
+        <a href="#cases">実績</a>
+        <a href="#contact">お問い合わせ</a>
+      </div>
+      <p class="footer-note">© 2024 Cometrue Strategy. All rights reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,288 @@
+:root {
+  color-scheme: light;
+  font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Segoe UI", sans-serif;
+  line-height: 1.6;
+  --primary: #1a4d8f;
+  --primary-dark: #10335f;
+  --accent: #f2c14e;
+  --text: #1d1d1f;
+  --muted: #6f7785;
+  --surface: #f4f7fb;
+  --border: #dde3ee;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  color: var(--text);
+  background: #fff;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.hero {
+  background: linear-gradient(135deg, #f7faff 0%, #e7eef8 50%, #d8e4f6 100%);
+  padding: 32px 80px 80px;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 20px;
+}
+
+.nav-links {
+  display: flex;
+  gap: 24px;
+  list-style: none;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.nav-cta {
+  background: var(--primary);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+}
+
+.hero-content {
+  margin-top: 80px;
+  max-width: 640px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 12px;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+h1 {
+  font-size: 48px;
+  line-height: 1.2;
+  margin: 16px 0;
+}
+
+.hero-copy {
+  font-size: 18px;
+  color: var(--muted);
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  margin: 32px 0;
+}
+
+.button {
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.button.primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+.button.ghost {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: #fff;
+}
+
+.hero-highlights {
+  display: flex;
+  gap: 32px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.highlight-number {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+
+.highlight-label {
+  display: block;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.section {
+  padding: 80px;
+}
+
+.section.alt {
+  background: var(--surface);
+}
+
+.section-header {
+  margin-bottom: 32px;
+  max-width: 640px;
+}
+
+.section-header h2 {
+  font-size: 32px;
+  margin-top: 12px;
+}
+
+.grid {
+  display: grid;
+  gap: 32px;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.grid.three {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: #fff;
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 12px 24px rgba(16, 51, 95, 0.08);
+}
+
+.card h3 {
+  margin-bottom: 12px;
+}
+
+.card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 24px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.check-list {
+  margin-top: 24px;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.check-list li::before {
+  content: "✔";
+  color: var(--accent);
+  margin-right: 8px;
+}
+
+.service,
+.case {
+  background: #fff;
+  border-radius: 14px;
+  padding: 24px;
+  border: 1px solid var(--border);
+}
+
+.service span {
+  display: inline-block;
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.contact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+}
+
+.contact-details {
+  margin-top: 24px;
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.contact-form {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 16px;
+}
+
+.contact-form label {
+  display: grid;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+input,
+textarea {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  font-size: 14px;
+}
+
+.footer {
+  padding: 48px 80px;
+  background: #101b2d;
+  color: #fff;
+  display: grid;
+  gap: 24px;
+}
+
+.footer-links {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  font-size: 14px;
+}
+
+.footer-note {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+@media (max-width: 900px) {
+  .hero,
+  .section,
+  .footer {
+    padding: 32px 24px;
+  }
+
+  .nav {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+  }
+
+  h1 {
+    font-size: 36px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a basic Japanese homepage for Cometrue Strategy with hero, services, cases, and contact sections to serve as the initial HP layout.
- Include a dedicated stylesheet to establish typography, color tokens, layout primitives, and responsive rules for the page.

### Description
- Add `index.html` containing the full page structure and copy in Japanese, including hero, about, services, cases, contact, and footer sections.
- Add `styles.css` with CSS custom properties, layout/grid rules, button styles, cards, and a mobile breakpoint at `900px`.
- Files staged and committed as part of the change set (`index.html` and `styles.css`).

### Testing
- Attempted an automated screenshot using Playwright (`page.screenshot`), but the browser process crashed (SIGSEGV) and the screenshot was not produced.
- No other automated tests were run in this rollout (static page assets only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968eb46e218832f8b8e5485d427763f)