### PR TITLE
fix(kokopelli-ec): 会員登録¥500OFFクーポンが届かない顧客苦情バグを修正

### DIFF
--- a/kokopelli-ec/src/app/api/member/register/route.ts
+++ b/kokopelli-ec/src/app/api/member/register/route.ts
@@ -1,110 +1,84 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
-import { MEMBER_SINGLE_PRICE, MEMBER_DISCOUNT_RATE } from '@/lib/prices';
+import { sendEmail } from '@/lib/email';
+import { buildMemberWelcomeEmail } from '@/lib/emails/member-welcome-template';
+import { PRICES } from '@/lib/prices';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
+// 会員登録特典の¥500OFFクーポン。ExitIntentPopup / カート放棄メールと共通の
+// Stripe プロモコード(既定 COMEBACK500)。env で上書き可。
+const WELCOME_COUPON_CODE = process.env.MEMBER_WELCOME_PROMO_CODE || 'COMEBACK500';
+
+/**
+ * 会員（メールマガジン）登録 — LP の MemberRegistration フォームから呼ばれる。
+ *
+ * 旧実装は checkout セッションを作って checkoutUrl を返すだけで、フォームが約束した
+ * 「¥500OFFクーポンをメールで送る」を一切実行していなかった（顧客苦情の根因）。
+ * 本実装で実際にクーポンメールを送付し、CRM 連携用に Stripe customer を upsert する。
+ */
 export async function POST(req: NextRequest) {
   try {
-    const secretKey = process.env.STRIPE_SECRET_KEY;
-    if (!secretKey) {
-      return NextResponse.json({ error: 'Stripe設定エラー' }, { status: 500 });
-    }
-
-    const stripe = new Stripe(secretKey, {
-      httpClient: Stripe.createFetchHttpClient(),
-    });
-
     const { email, name } = await req.json();
 
-    // email のみ必須。name はフォーム(MemberRegistration)が送らないためオプショナル。
-    if (!email || typeof email !== 'string') {
+    if (!email || typeof email !== 'string' || !email.includes('@')) {
       return NextResponse.json({ error: 'メールアドレスを入力してください' }, { status: 400 });
     }
     const customerName: string = typeof name === 'string' ? name.trim() : '';
 
-    // Check if customer already exists
-    const existing = await stripe.customers.list({
-      email,
-      limit: 1,
-    });
-
-    let customer: Stripe.Customer;
-    let isFirstTime = true;
-
-    if (existing.data.length > 0) {
-      customer = existing.data[0];
-      // Check if they've already used the first-time offer
-      if (customer.metadata?.first_trial_used === 'true') {
-        isFirstTime = false;
-      }
-    } else {
-      // Create new customer (name は任意 — 空の場合は送らない)
-      customer = await stripe.customers.create({
-        email,
-        ...(customerName ? { name: customerName } : {}),
-        metadata: {
-          first_trial_used: 'false',
-          member_since: new Date().toISOString(),
-          source: 'kokopelli-ec',
-        },
-      });
-    }
-
-    const siteUrl = 'https://kokopelli.kamuturu.jp';
-
-    // Create checkout session with member price (5% off) — 価格は prices.ts が唯一の真実
-    const unitAmount = MEMBER_SINGLE_PRICE; // ¥3,306 (= SINGLE_PRICE × 95%)
-    const offPercent = Math.round(MEMBER_DISCOUNT_RATE * 100); // 5
-    const productName = `【会員価格】ココペリ 1本（${offPercent}%OFF）`;
-    const productDesc = `犬・猫のための動物用栄養補助食品 水溶性ケイ素濃縮液 30ml（会員価格${offPercent}%OFF・税込）※30日間返金保証付き`;
-
-    const session = await stripe.checkout.sessions.create({
-      mode: 'payment',
-      customer: customer.id,
-      // konbini はStripe口座で未有効化のため指定するとセッション生成が400で落ちる。
-      // カード決済に統一（本流 /checkout・/subscribe と同じ挙動）。
-      payment_method_types: ['card'],
-      line_items: [
-        {
-          price_data: {
-            currency: 'jpy',
-            product_data: {
-              name: productName,
-              description: productDesc,
+    // ── Stripe customer を find-or-create して購読者として記録（CRM 連携用）──
+    // Stripe 側の失敗は致命としない。クーポンメールの配信を最優先する。
+    const secretKey = process.env.STRIPE_SECRET_KEY;
+    if (secretKey) {
+      try {
+        const stripe = new Stripe(secretKey, {
+          httpClient: Stripe.createFetchHttpClient(),
+        });
+        const existing = await stripe.customers.list({ email, limit: 1 });
+        if (existing.data.length === 0) {
+          await stripe.customers.create({
+            email,
+            ...(customerName ? { name: customerName } : {}),
+            metadata: {
+              member_since: new Date().toISOString(),
+              newsletter_opt_in: 'true',
+              source: 'kokopelli-ec',
             },
-            unit_amount: unitAmount,
-          },
-          quantity: 1,
-        },
-      ],
-      shipping_address_collection: {
-        allowed_countries: ['JP'],
-      },
-      metadata: {
-        member_email: email,
-        is_first_trial: isFirstTime ? 'true' : 'false',
-      },
-      success_url: `${siteUrl}/success?session_id={CHECKOUT_SESSION_ID}&member=true`,
-      cancel_url: `${siteUrl}/#member`,
-    });
-
-    // Mark first trial as used (will be confirmed on webhook)
-    if (isFirstTime) {
-      await stripe.customers.update(customer.id, {
-        metadata: {
-          ...customer.metadata,
-          first_trial_used: 'true',
-          first_trial_date: new Date().toISOString(),
-        },
-      });
+          });
+        } else {
+          // 既存顧客には購読フラグだけ補記。first_trial_used 等の購入関連は触らない。
+          const c = existing.data[0];
+          if (c.metadata?.newsletter_opt_in !== 'true') {
+            await stripe.customers.update(c.id, {
+              metadata: { ...c.metadata, newsletter_opt_in: 'true' },
+            });
+          }
+        }
+      } catch (e) {
+        console.error('[member/register] Stripe customer upsert 失敗:', e);
+      }
     }
 
+    // ── 約束どおり ¥500OFF クーポンをメールで送付 ──
+    let emailSent = false;
+    try {
+      const { subject, text, html } = buildMemberWelcomeEmail({
+        customerName,
+        couponCode: WELCOME_COUPON_CODE,
+        couponAmountOff: PRICES.referralDiscount,
+      });
+      await sendEmail({ to: email, subject, text, html });
+      emailSent = true;
+    } catch (e) {
+      console.error('[member/register] ウェルカムメール送信失敗:', e);
+    }
+
+    // クーポンコードは画面側でも即時表示する（メール不達でも特典を確実に渡す）。
     return NextResponse.json({
-      checkoutUrl: session.url,
-      isFirstTime,
-      memberId: customer.id,
+      ok: true,
+      couponCode: WELCOME_COUPON_CODE,
+      emailSent,
     });
   } catch (error: unknown) {
     console.error('Member registration error:', error);

--- a/kokopelli-ec/src/app/components/MemberRegistration.tsx
+++ b/kokopelli-ec/src/app/components/MemberRegistration.tsx
@@ -4,10 +4,16 @@ import { useState } from 'react';
 
 type Status = 'idle' | 'submitting' | 'success' | 'error';
 
+// API が couponCode を返せなかった場合のフォールバック（ExitIntentPopup と共通）。
+const FALLBACK_COUPON = 'COMEBACK500';
+
 export default function MemberRegistration() {
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<Status>('idle');
   const [errorMessage, setErrorMessage] = useState('');
+  const [couponCode, setCouponCode] = useState(FALLBACK_COUPON);
+  const [emailSent, setEmailSent] = useState(true);
+  const [copied, setCopied] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -28,11 +34,15 @@ export default function MemberRegistration() {
       });
 
       if (!res.ok) {
-        if (res.status === 404) {
-          setStatus('success');
-          return;
-        }
         throw new Error(`サーバーエラー (${res.status})`);
+      }
+
+      const data = await res.json().catch(() => ({}));
+      if (typeof data.couponCode === 'string' && data.couponCode) {
+        setCouponCode(data.couponCode);
+      }
+      if (typeof data.emailSent === 'boolean') {
+        setEmailSent(data.emailSent);
       }
       setStatus('success');
     } catch (err) {
@@ -41,13 +51,64 @@ export default function MemberRegistration() {
     }
   };
 
+  const copyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(couponCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      const ta = document.createElement('textarea');
+      ta.value = couponCode;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand('copy');
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        // noop
+      }
+      document.body.removeChild(ta);
+    }
+  };
+
   if (status === 'success') {
     return (
       <div className="bg-amber-50 border-2 border-amber-200 rounded-2xl p-8 text-center">
-        <p className="text-2xl mb-2">✉️</p>
-        <p className="font-bold text-slate-900 mb-2">登録ありがとうございます！</p>
-        <p className="text-sm text-slate-600">
-          ご登録のメールアドレス宛に、500円OFFクーポンをお送りします。
+        <p className="text-2xl mb-2">🎉</p>
+        <p className="font-bold text-slate-900 mb-3">ご登録ありがとうございます！</p>
+        <p className="text-sm text-slate-600 mb-4">
+          下記の500円OFFクーポンを、決済画面の
+          <span className="font-bold text-amber-700">「クーポン」欄</span>にご入力ください。
+        </p>
+
+        <div className="bg-white border-2 border-amber-300 rounded-xl p-4 mb-3">
+          <p className="text-xs text-amber-800 mb-1">クーポンコード</p>
+          <p className="font-mono font-black text-3xl text-amber-700 tracking-widest">
+            {couponCode}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={copyCode}
+          className="w-full rounded-full bg-amber-600 hover:bg-amber-500 active:bg-amber-700 py-3 font-bold text-white shadow mb-2"
+        >
+          {copied ? '✓ コピーしました' : 'コードをコピー'}
+        </button>
+        <a
+          href="/checkout"
+          className="block w-full text-center rounded-full bg-slate-800 hover:bg-slate-700 py-3 font-bold text-white shadow"
+        >
+          このまま購入ページへ進む
+        </a>
+
+        <p className="mt-3 text-xs text-slate-500 leading-relaxed">
+          {emailSent
+            ? '同じクーポンをご登録のメールアドレス宛にもお送りしました。届かない場合は迷惑メールフォルダもご確認ください。'
+            : 'このクーポンコードを忘れずにお控えください。'}
         </p>
       </div>
     );

--- a/kokopelli-ec/src/lib/emails/member-welcome-template.ts
+++ b/kokopelli-ec/src/lib/emails/member-welcome-template.ts
@@ -1,0 +1,145 @@
+/**
+ * 会員登録ウェルカムメールテンプレート
+ *
+ * LP の「無料で登録して500円OFFを受け取る」フォーム(MemberRegistration)から
+ * 登録したユーザーに、約束した ¥500OFF クーポンを即時お届けする。
+ *
+ * クーポンコードは ExitIntentPopup / カート放棄メールと共通の Stripe プロモコード
+ * (既定 COMEBACK500)。/checkout・/subscribe は allow_promotion_codes: true なので
+ * 決済画面の「クーポン」欄に入力すれば適用される。
+ *
+ * 使い方:
+ *   const { subject, text, html } = buildMemberWelcomeEmail({
+ *     customerName: '山田',
+ *     couponCode: 'COMEBACK500',
+ *     couponAmountOff: 500,
+ *   });
+ */
+
+import { formatYen, PRICES } from '@/lib/prices';
+
+export interface MemberWelcomeVars {
+  /** 顧客名（未取得なら「お客様」） */
+  customerName?: string;
+  /** クーポンコード（Stripe プロモコード） */
+  couponCode: string;
+  /** クーポン割引額（円）。デフォルト ¥500 */
+  couponAmountOff?: number;
+}
+
+export interface MemberWelcomeEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+const BRAND_AMBER = '#d97706'; // amber-600
+const BRAND_SLATE = '#1e293b'; // slate-800
+const BG_SOFT = '#fffbeb'; // amber-50
+const CHECKOUT_URL = 'https://kokopelli.kamuturu.jp/checkout';
+
+/**
+ * 会員登録ウェルカム（¥500OFFクーポン同封）メールを生成
+ */
+export function buildMemberWelcomeEmail(vars: MemberWelcomeVars): MemberWelcomeEmail {
+  const name = vars.customerName?.trim() || 'お客様';
+  const couponAmount = vars.couponAmountOff ?? PRICES.referralDiscount; // デフォルト ¥500
+  const code = vars.couponCode;
+
+  const subject = `【ご登録ありがとうございます】${formatYen(couponAmount)}OFFクーポンをお届けします — ココペリ シリカウォーター`;
+
+  // ========== プレーンテキスト ==========
+  const text = [
+    `${name}、こんにちは。`,
+    `ココペリ シリカウォーターです。`,
+    ``,
+    `この度は会員登録いただき、誠にありがとうございます。`,
+    `ご登録特典として、${formatYen(couponAmount)}OFFクーポンをお届けします。`,
+    ``,
+    `━━━ ご登録特典クーポン ━━━`,
+    `クーポンコード: ${code}`,
+    `割引額: ${formatYen(couponAmount)}OFF`,
+    `決済画面の「クーポン」欄にご入力ください。`,
+    `お早めのご利用をおすすめします。`,
+    `━━━━━━━━━━━━━━━━━━`,
+    ``,
+    `▼ お買い物はこちらから`,
+    `${CHECKOUT_URL}`,
+    ``,
+    `ココペリは、犬・猫のための水溶性ケイ素濃縮液（動物用栄養補助食品）です。`,
+    `毎日のお水に数滴加えるだけでお使いいただけます。`,
+    ``,
+    `ご不明点がございましたら、このメールへ返信ください。`,
+    `担当者より折り返しご連絡いたします。`,
+    ``,
+    `ココペリ シリカウォーター`,
+    `https://kokopelli.kamuturu.jp`,
+  ].join('\n');
+
+  // ========== HTML ==========
+  const html = `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${subject}</title>
+</head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic UI',sans-serif;color:${BRAND_SLATE};">
+  <table role="presentation" width="100%" style="background:#f8fafc;padding:24px 0;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" style="max-width:600px;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+          <tr>
+            <td style="background:${BRAND_SLATE};padding:24px 32px;text-align:center;">
+              <h1 style="margin:0;color:#ffffff;font-size:20px;font-weight:600;">ココペリ シリカウォーター</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:32px;">
+              <p style="margin:0 0 16px;font-size:16px;">${name}、こんにちは。</p>
+              <p style="margin:0 0 16px;font-size:15px;line-height:1.7;">
+                この度は会員登録いただき、誠にありがとうございます。<br>
+                ご登録特典として <strong style="color:${BRAND_AMBER};">${formatYen(couponAmount)}OFFクーポン</strong> をお届けします。
+              </p>
+              <table role="presentation" width="100%" style="margin:24px 0;border-collapse:collapse;">
+                <tr>
+                  <td style="background:${BG_SOFT};border:2px dashed ${BRAND_AMBER};border-radius:8px;padding:20px;text-align:center;">
+                    <p style="margin:0 0 8px;color:${BRAND_SLATE};font-size:13px;letter-spacing:0.1em;">ご登録特典クーポン</p>
+                    <p style="margin:0 0 8px;color:${BRAND_AMBER};font-size:28px;font-weight:700;">${formatYen(couponAmount)} OFF</p>
+                    <p style="margin:0 0 12px;color:${BRAND_SLATE};font-size:18px;font-weight:600;font-family:monospace;letter-spacing:0.15em;">${code}</p>
+                    <p style="margin:0;color:#64748b;font-size:12px;">決済画面の「クーポン」欄にご入力ください</p>
+                  </td>
+                </tr>
+              </table>
+              <table role="presentation" width="100%" style="margin:24px 0;">
+                <tr>
+                  <td align="center">
+                    <a href="${CHECKOUT_URL}" style="display:inline-block;background:${BRAND_AMBER};color:#ffffff;text-decoration:none;padding:16px 40px;border-radius:8px;font-size:16px;font-weight:600;">
+                      お買い物をはじめる
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:24px 0 0;font-size:14px;color:#475569;line-height:1.7;">
+                ココペリは、犬・猫のための水溶性ケイ素濃縮液（動物用栄養補助食品）です。毎日のお水に数滴加えるだけでお使いいただけます。
+              </p>
+              <p style="margin:16px 0 0;font-size:13px;color:#64748b;line-height:1.6;">
+                ご不明点がございましたら、このメールへ返信ください。<br>
+                担当者より折り返しご連絡いたします。
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="background:#f1f5f9;padding:16px 32px;text-align:center;font-size:12px;color:#64748b;">
+              ココペリ シリカウォーター / <a href="https://kokopelli.kamuturu.jp" style="color:${BRAND_AMBER};text-decoration:none;">kokopelli.kamuturu.jp</a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+  return { subject, text, html };
+}


### PR DESCRIPTION
## 背景（実在顧客からの苦情）

LPの会員登録フォーム（`MemberRegistration`）は **「無料で登録して500円OFFを受け取る」** と約束しているが、登録APIがクーポンメールを **一切送っていなかった**。実在顧客 maruko_1029 様から info@kamuturu.jp へ「登録したのに何も返信が来ない。システムが稼働していないのか」という苦情が2回届いた。

### 根本原因（確定）

`/api/member/register` は POST を受けると **Stripe checkout セッションを作って `checkoutUrl` を返すだけ**で、`sendEmail` を呼ぶコードを持っていなかった。メール基盤（`src/lib/email.ts` の nodemailer/Gmail SMTP）も本番 env（`GMAIL_USER`/`GMAIL_APP_PASSWORD`）も正常 → 唯一の原因は「登録APIがメールを送っていない」こと。全登録者に対して **嘘の約束** をしていた状態。

加えて、無料登録しただけで Stripe customer に `first_trial_used='true'` をマークし、**顧客の初回購入特典を潰す潜在バグ**もあった。

## 修正内容（3ファイル）

| ファイル | 変更 |
|---|---|
| `src/app/api/member/register/route.ts` | checkout セッション生成と `first_trial_used` マーキングを削除。約束どおり ¥500OFF クーポン（`COMEBACK500` / env `MEMBER_WELCOME_PROMO_CODE` で上書き可）をウェルカムメールで送付。Stripe customer は `newsletter_opt_in` タグで upsert（CRM連携・失敗しても登録は成功扱い）。`{ok, couponCode, emailSent}` を返す |
| `src/lib/emails/member-welcome-template.ts`（新規） | ¥500OFFクーポン同封のウェルカムメール（text+HTML）。価格は `prices.ts` 参照（ハードコード禁止）、薬機法に配慮し「犬・猫のための水溶性ケイ素濃縮液（動物用栄養補助食品）」と中立記述 |
| `src/app/components/MemberRegistration.tsx` | 成功画面でクーポンコードを**画面にも大きく表示＋コピーボタン**化（メール不達でも特典を確実に渡す）。バグを隠していた 404-as-success ハックを削除。`emailSent` に応じてメッセージ出し分け |

## 設計判断

- **新規 Stripe クーポンは作成していない**。`COMEBACK500` は ExitIntentPopup / カート放棄メールで既に前提にしている店舗共通プロモコードを再利用するため、「Stripe本番操作は必ずユーザーに確認」ルールに抵触しない。
- メールと画面表示の **二重化** で、メール不達でも特典を確実に届け苦情再発を防ぐ。

## 検証

- `tsc --noEmit` exit 0
- `npm run build` 成功（ルートテーブルに `/api/member/register` 含む・エラー行なし）

## マージ前のRay確認事項

- [ ] **`COMEBACK500` が Stripe Live に実在するか**（コードは3箇所で前提にしているが直接確認が必要。無ければ Stripe Dashboard で ¥500 OFF のプロモコードとして作成）
- [ ] マージ承認（auto-merge はしていません）

🤖 Generated with [Claude Code](https://claude.com/claude-code)