### PR TITLE
fix(kokopelli-ec): 再接客メール死リンク一掃＋ログイン画面に会員登録導線

### DIFF
--- a/kokopelli-ec/scripts/generate-videos-v1.py
+++ b/kokopelli-ec/scripts/generate-videos-v1.py
@@ -240,7 +240,7 @@ def build_video_a(size, out_path):
             cta_txt, font=f_main, fill=WHITE)
 
     # 小さい注記
-    note = "kokopelli.kamuturu.jp"
+    note = "kokopelli-ec.vercel.app"
     nb = cd.textbbox((0, 0), note, font=f_small)
     cd.text(((W - (nb[2] - nb[0])) // 2, y_cursor + cta_h + int(H * 0.04)),
             note, font=f_small, fill=TEXT_DARK)
@@ -372,7 +372,7 @@ def build_video_b(size, out_path):
     cd.text(((W - (cb[2] - cb[0])) // 2, y_cursor + (cta_h - (cb[3] - cb[1])) // 2 - 10),
             cta_txt, font=f_main, fill=WHITE)
 
-    note = "kokopelli.kamuturu.jp"
+    note = "kokopelli-ec.vercel.app"
     nb = cd.textbbox((0, 0), note, font=f_small)
     cd.text(((W - (nb[2] - nb[0])) // 2, y_cursor + cta_h + int(H * 0.04)),
             note, font=f_small, fill=TEXT_DARK)

--- a/kokopelli-ec/scripts/generate-videos-v2.py
+++ b/kokopelli-ec/scripts/generate-videos-v2.py
@@ -458,7 +458,7 @@ VARIANTS = {
         "cta_label": "まずは1本",
         "cta_price": f"¥{SINGLE_PRICE:,}",
         "cta_text": "公式サイトで詳細を見る",
-        "cta_url": "kokopelli.kamuturu.jp",
+        "cta_url": "kokopelli-ec.vercel.app",
         "bgm": r"C:\Users\timbe\youtube-auto\assets\bgm\emotional_strings.wav",
     },
     "B": {
@@ -479,7 +479,7 @@ VARIANTS = {
         "cta_label": "お試し1本",
         "cta_price": f"¥{SINGLE_PRICE:,}",
         "cta_text": "公式サイトで詳細を見る",
-        "cta_url": "kokopelli.kamuturu.jp",
+        "cta_url": "kokopelli-ec.vercel.app",
         "bgm": r"C:\Users\timbe\youtube-auto\assets\bgm\cute_bgm.wav",
     },
 }

--- a/kokopelli-ec/scripts/list-unordered-members.mjs
+++ b/kokopelli-ec/scripts/list-unordered-members.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * kokopelli-ec 「登録済み・未購入」の暖かいリード抽出
+ *
+ * 会員登録(Stripe customer 作成・metadata.source='kokopelli-ec')だけして
+ * **一度も決済が成功していない・定期便も無い**顧客のメール一覧を出力する。
+ * → konbini 400 バグ(2026-05-27 修正済 commit 01cf3c7)で買えなかった層の回収用。
+ *
+ * 環境変数 KOKOPELLI_STRIPE_LIVE_KEY (sk_live_ / rk_live_) を読む。
+ * シークレットキーは一切標準出力に出さない設計。
+ *
+ * 使い方:
+ *   node scripts/list-unordered-members.mjs            // 全期間の登録会員
+ *   node scripts/list-unordered-members.mjs 90         // 直近90日に登録した会員に限定
+ *   KOKO_KEY_VAR=STRIPE_LIVE_SECRET_KEY node scripts/list-unordered-members.mjs
+ */
+
+import { execFileSync } from 'node:child_process';
+
+function readUserEnvFromRegistry(name) {
+  if (process.platform !== 'win32') return null;
+  try {
+    const out = execFileSync('reg.exe', ['query', 'HKCU\\Environment', '/v', name], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const m = out.match(/REG_(?:EXPAND_)?SZ\s+(.+?)\s*$/m);
+    return m ? m[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+// 既定は KOKOPELLI_STRIPE_LIVE_KEY。別名で登録済みなら KOKO_KEY_VAR で上書き可。
+const VAR_NAME = process.env.KOKO_KEY_VAR || 'KOKOPELLI_STRIPE_LIVE_KEY';
+const KEY = process.env[VAR_NAME] || readUserEnvFromRegistry(VAR_NAME);
+if (!KEY) {
+  console.error(`❌ ${VAR_NAME} が未設定です（User env / HKCU\\Environment 両方）。`);
+  console.error(
+    '   別名で登録済みなら: KOKO_KEY_VAR=<変数名> node scripts/list-unordered-members.mjs'
+  );
+  process.exit(1);
+}
+if (!/^(sk|rk)_live_/.test(KEY)) {
+  console.error(
+    `❌ ${VAR_NAME} は本番キー (sk_live_ / rk_live_) ではありません。テストキーでは実顧客は見えません。`
+  );
+  process.exit(1);
+}
+console.log(`🔑 使用キー変数: ${VAR_NAME}（値は非表示）`);
+
+// 任意: 直近N日に登録した会員に限定（未指定なら全期間）
+const days = Number(process.argv[2]) > 0 ? Number(process.argv[2]) : 0;
+const sinceSec = days > 0 ? Math.floor(Date.now() / 1000) - days * 86400 : 0;
+
+async function stripeGet(path, params = {}) {
+  const url = new URL('https://api.stripe.com/v1/' + path);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  const res = await fetch(url, { headers: { Authorization: 'Bearer ' + KEY } });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Stripe ${path} ${res.status}: ${body.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+async function pageAll(path, params) {
+  const out = [];
+  let starting_after;
+  for (let i = 0; i < 50; i++) {
+    const q = { limit: '100', ...params };
+    if (starting_after) q.starting_after = starting_after;
+    const j = await stripeGet(path, q);
+    out.push(...j.data);
+    if (!j.has_more || j.data.length === 0) break;
+    starting_after = j.data[j.data.length - 1].id;
+  }
+  return out;
+}
+
+(async () => {
+  try {
+    console.log('\n=== kokopelli-ec 登録済み・未購入の暖かいリード抽出 ===');
+    console.log(days > 0 ? `対象: 直近${days}日に登録した会員\n` : '対象: 全期間の登録会員\n');
+
+    // 1) 決済が成功した顧客ID集合（charges 全期間）
+    const charges = await pageAll('charges', {});
+    const paidCustomerIds = new Set(
+      charges
+        .filter((c) => c.paid && c.status === 'succeeded' && !c.refunded && c.customer)
+        .map((c) => c.customer)
+    );
+
+    // 2) 定期便を持つ顧客ID集合（全status — 過去解約も「購入経験あり」として除外）
+    const subs = await pageAll('subscriptions', { status: 'all' });
+    const subCustomerIds = new Set(subs.map((s) => s.customer).filter(Boolean));
+
+    // 3) 全顧客を取得し、source='kokopelli-ec' かつ 上記いずれにも属さない＝未購入を抽出
+    const customers = await pageAll('customers', {});
+    const warmLeads = customers.filter((cust) => {
+      if (cust.metadata?.source !== 'kokopelli-ec') return false; // 自社EC登録のみ
+      if (days > 0 && cust.created < sinceSec) return false; // 期間フィルタ
+      if (paidCustomerIds.has(cust.id)) return false; // 購入済みは除外
+      if (subCustomerIds.has(cust.id)) return false; // 定期便ありは除外
+      if (cust.email && /@example\.(com|net|org)$/i.test(cust.email)) return false; // 動作検証用ダミーは除外
+      return true;
+    });
+
+    // 登録が新しい順
+    warmLeads.sort((a, b) => b.created - a.created);
+
+    console.log(`【全customer数】 ${customers.length}件`);
+    console.log(`【決済成功した顧客】 ${paidCustomerIds.size}件`);
+    console.log(`【定期便を持つ顧客】 ${subCustomerIds.size}件`);
+    console.log(`\n★ 登録済み・未購入の暖かいリード: ${warmLeads.length}件\n`);
+
+    if (warmLeads.length === 0) {
+      console.log('（該当なし）\n');
+    } else {
+      console.log('登録日(UTC)        メールアドレス                       お名前');
+      console.log('-----------------------------------------------------------------------');
+      warmLeads.forEach((c) => {
+        const d = new Date(c.created * 1000).toISOString().slice(0, 16).replace('T', ' ');
+        const email = (c.email || '(メール無)').padEnd(34);
+        const name = c.name || '';
+        console.log(`${d}  ${email}  ${name}`);
+      });
+      console.log('');
+
+      // 再接客メールにそのまま貼れるよう、メールだけのカンマ区切りも出力
+      const emails = warmLeads.map((c) => c.email).filter(Boolean);
+      if (emails.length) {
+        console.log('--- メールのみ（BCC/差し込み用・カンマ区切り） ---');
+        console.log(emails.join(', '));
+        console.log('');
+      }
+    }
+
+    console.log('=== ここまで（メール一覧のみ／secret非出力） ===\n');
+  } catch (e) {
+    console.error('❌ 照会失敗:', e.message);
+    process.exit(2);
+  }
+})();

--- a/kokopelli-ec/scripts/nouhinsho/form.html
+++ b/kokopelli-ec/scripts/nouhinsho/form.html
@@ -1,0 +1,692 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>納品書フォーム - ココペリ</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: 'Meiryo', 'Yu Gothic', sans-serif;
+        padding: 24px;
+        max-width: 1200px;
+        margin: 0 auto;
+        background: #f9fafb;
+      }
+      h1 {
+        color: #d97706;
+        margin-bottom: 16px;
+      }
+      .layout {
+        display: grid;
+        grid-template-columns: 420px 1fr;
+        gap: 24px;
+      }
+      .form-card {
+        background: #fff;
+        padding: 20px;
+        border-radius: 8px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      }
+      .preview-card {
+        background: #fff;
+        padding: 20px;
+        border-radius: 8px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        max-height: 90vh;
+        overflow: auto;
+      }
+      label {
+        display: block;
+        margin-bottom: 12px;
+        font-size: 13px;
+        color: #374151;
+      }
+      label strong {
+        display: block;
+        margin-bottom: 4px;
+        color: #111;
+      }
+      input,
+      select,
+      textarea {
+        width: 100%;
+        padding: 8px 10px;
+        border: 1px solid #d1d5db;
+        border-radius: 4px;
+        font-size: 13px;
+        font-family: inherit;
+      }
+      .row2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+      .preset-bar {
+        display: flex;
+        gap: 6px;
+        margin-bottom: 12px;
+        flex-wrap: wrap;
+      }
+      .preset-bar button {
+        background: #fef3c7;
+        border: 1px solid #d97706;
+        color: #92400e;
+        padding: 6px 10px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px;
+      }
+      .preset-bar button:hover {
+        background: #fde68a;
+      }
+      .actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 16px;
+      }
+      .actions button {
+        flex: 1;
+        padding: 10px;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: bold;
+      }
+      .btn-print {
+        background: #d97706;
+        color: #fff;
+      }
+      .btn-print:hover {
+        background: #b45309;
+      }
+      .btn-download {
+        background: #374151;
+        color: #fff;
+      }
+      .btn-download:hover {
+        background: #1f2937;
+      }
+      .item-row {
+        background: #f3f4f6;
+        padding: 10px;
+        border-radius: 4px;
+        margin-bottom: 8px;
+      }
+      .item-row .row3 {
+        display: grid;
+        grid-template-columns: 2fr 60px 100px;
+        gap: 6px;
+      }
+      .item-row .full {
+        margin-top: 6px;
+      }
+      .item-actions {
+        display: flex;
+        gap: 6px;
+        margin-top: 8px;
+      }
+      .item-actions button {
+        flex: 1;
+        padding: 6px;
+        border: 1px solid #d1d5db;
+        background: #fff;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px;
+      }
+      @media print {
+        body {
+          background: #fff;
+          padding: 0;
+          max-width: 800px;
+        }
+        .form-card,
+        .preset-bar,
+        .actions,
+        h1.page-title {
+          display: none !important;
+        }
+        .layout {
+          grid-template-columns: 1fr;
+          gap: 0;
+        }
+        .preview-card {
+          box-shadow: none;
+          padding: 0;
+          max-height: none;
+          overflow: visible;
+        }
+      }
+      .doc {
+        font-family: 'Meiryo', 'Yu Gothic', sans-serif;
+        color: #333;
+      }
+      .doc .header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 32px;
+        padding-bottom: 16px;
+        border-bottom: 3px solid #d97706;
+      }
+      .doc .header h1 {
+        font-size: 26px;
+        color: #d97706;
+        letter-spacing: 0.2em;
+        margin: 0;
+      }
+      .doc .doc-info {
+        text-align: right;
+        font-size: 12px;
+        color: #666;
+      }
+      .doc .section {
+        margin-bottom: 24px;
+      }
+      .doc .section h2 {
+        font-size: 13px;
+        color: #d97706;
+        margin-bottom: 8px;
+        padding-bottom: 4px;
+        border-bottom: 1px solid #e5e7eb;
+      }
+      .doc table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      .doc .info-table td {
+        padding: 5px 0;
+        font-size: 13px;
+      }
+      .doc .info-table td:first-child {
+        width: 90px;
+        color: #666;
+        font-weight: bold;
+      }
+      .doc .item-table th {
+        background: #fef3c7;
+        padding: 8px;
+        text-align: left;
+        font-size: 12px;
+        border-bottom: 2px solid #d97706;
+      }
+      .doc .item-table td {
+        padding: 8px;
+        font-size: 13px;
+        border-bottom: 1px solid #e5e7eb;
+      }
+      .doc .item-table .right {
+        text-align: right;
+      }
+      .doc .total-row td {
+        font-weight: bold;
+        font-size: 15px;
+        border-top: 2px solid #333;
+        padding-top: 10px;
+      }
+      .doc .total-amount {
+        font-size: 22px;
+        color: #d97706;
+      }
+      .doc .footer {
+        margin-top: 30px;
+        padding-top: 16px;
+        border-top: 1px solid #e5e7eb;
+        font-size: 11px;
+        color: #999;
+        text-align: center;
+      }
+      .doc .stamp-area {
+        margin-top: 24px;
+        display: flex;
+        justify-content: flex-end;
+      }
+      .doc .stamp-box {
+        width: 80px;
+        height: 80px;
+        border: 1px dashed #ccc;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #ccc;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1 class="page-title">納品書フォーム — ココペリ シリカウォーター</h1>
+    <div class="layout">
+      <div class="form-card">
+        <div class="preset-bar">
+          <button onclick="loadPreset('single')">1本¥3,480</button>
+          <button onclick="loadPreset('bundle2')">2本¥5,980</button>
+          <button onclick="loadPreset('bundle6')">6本¥15,000</button>
+          <button onclick="loadPreset('sub')">定期¥5,480</button>
+        </div>
+
+        <label><strong>納品書番号</strong><input id="docNo" /></label>
+        <div class="row2">
+          <label><strong>発行日</strong><input id="issueDate" type="date" /></label>
+          <label><strong>納品日</strong><input id="deliveryDate" type="date" /></label>
+        </div>
+
+        <h3
+          style="
+            font-size: 13px;
+            color: #d97706;
+            margin: 16px 0 8px;
+            border-bottom: 1px solid #e5e7eb;
+            padding-bottom: 4px;
+          "
+        >
+          お届け先
+        </h3>
+        <label><strong>お名前</strong><input id="custName" placeholder="山田 太郎" /></label>
+        <div class="row2">
+          <label><strong>郵便番号</strong><input id="custPostal" placeholder="100-0001" /></label>
+          <label><strong>電話</strong><input id="custPhone" placeholder="090-0000-0000" /></label>
+        </div>
+        <label
+          ><strong>ご住所</strong><input id="custAddress" placeholder="東京都千代田区..."
+        /></label>
+        <label
+          ><strong>メール</strong
+          ><input id="custEmail" type="email" placeholder="customer@example.com"
+        /></label>
+
+        <h3
+          style="
+            font-size: 13px;
+            color: #d97706;
+            margin: 16px 0 8px;
+            border-bottom: 1px solid #e5e7eb;
+            padding-bottom: 4px;
+          "
+        >
+          ご注文内容
+        </h3>
+        <div id="items"></div>
+        <div class="item-actions">
+          <button onclick="addItem()">＋ 商品追加</button>
+        </div>
+
+        <div class="row2" style="margin-top: 12px">
+          <label><strong>送料</strong><input id="shipping" type="number" value="520" /></label>
+          <label
+            ><strong>　</strong>
+            <select
+              id="shippingPreset"
+              onchange="
+                document.getElementById('shipping').value = this.value;
+                render();
+              "
+            >
+              <option value="520">¥520（1本）</option>
+              <option value="0">¥0（送料無料）</option>
+            </select>
+          </label>
+        </div>
+
+        <h3
+          style="
+            font-size: 13px;
+            color: #d97706;
+            margin: 16px 0 8px;
+            border-bottom: 1px solid #e5e7eb;
+            padding-bottom: 4px;
+          "
+        >
+          お支払い
+        </h3>
+        <label
+          ><strong>決済方法</strong>
+          <select id="payMethod">
+            <option>クレジットカード（Stripe決済）</option>
+            <option>銀行振込</option>
+            <option>代金引換</option>
+            <option>LINE Pay</option>
+          </select>
+        </label>
+        <div class="row2">
+          <label><strong>決済日</strong><input id="payDate" type="date" /></label>
+          <label
+            ><strong>ステータス</strong>
+            <select id="payStatus">
+              <option>お支払い済み</option>
+              <option>未払い</option>
+              <option>処理中</option>
+            </select>
+          </label>
+        </div>
+        <label
+          ><strong>取引ID（Stripe pi_xxx 等）</strong><input id="payId" placeholder="pi_3..."
+        /></label>
+
+        <div class="actions">
+          <button class="btn-print" onclick="window.print()">🖨️ 印刷 / PDF保存</button>
+          <button class="btn-download" onclick="downloadHTML()">💾 HTMLダウンロード</button>
+        </div>
+        <div class="actions">
+          <button class="btn-download" onclick="saveJSON()" style="background: #6b7280">
+            📋 JSON保存
+          </button>
+          <button class="btn-download" onclick="loadJSON()" style="background: #6b7280">
+            📂 JSON読込
+          </button>
+        </div>
+      </div>
+
+      <div class="preview-card">
+        <div id="preview" class="doc"></div>
+      </div>
+    </div>
+
+    <script>
+      const PRESETS = {
+        single: {
+          name: 'ココペリ シリカウォーター 1本',
+          note: '動物用栄養補助食品（水溶性ケイ素濃縮液）',
+          qty: 1,
+          unitPrice: 3480,
+          shipping: 520,
+        },
+        bundle2: {
+          name: 'ココペリ シリカウォーター 2本セット',
+          note: '動物用栄養補助食品（水溶性ケイ素濃縮液）',
+          qty: 1,
+          unitPrice: 5980,
+          shipping: 0,
+        },
+        bundle6: {
+          name: 'ココペリ シリカウォーター 6本セット（5+1）',
+          note: '動物用栄養補助食品（水溶性ケイ素濃縮液）',
+          qty: 1,
+          unitPrice: 15000,
+          shipping: 0,
+        },
+        sub: {
+          name: 'ココペリ シリカウォーター 定期便（2本/月）',
+          note: '動物用栄養補助食品（水溶性ケイ素濃縮液）',
+          qty: 1,
+          unitPrice: 5480,
+          shipping: 0,
+        },
+      };
+
+      let items = [];
+
+      function loadPreset(key) {
+        const p = PRESETS[key];
+        items = [{ name: p.name, note: p.note, qty: p.qty, unitPrice: p.unitPrice }];
+        document.getElementById('shipping').value = p.shipping;
+        document.getElementById('shippingPreset').value = p.shipping;
+        renderItems();
+        render();
+      }
+
+      function addItem() {
+        items.push({ name: '', note: '', qty: 1, unitPrice: 0 });
+        renderItems();
+        render();
+      }
+
+      function removeItem(i) {
+        items.splice(i, 1);
+        renderItems();
+        render();
+      }
+
+      function renderItems() {
+        const c = document.getElementById('items');
+        c.innerHTML = items
+          .map(
+            (it, i) => `
+          <div class="item-row">
+            <div class="row3">
+              <input placeholder="商品名" value="${escapeAttr(it.name)}" onchange="items[${i}].name=this.value;render()" />
+              <input type="number" placeholder="数量" value="${it.qty}" onchange="items[${i}].qty=Number(this.value);render()" />
+              <input type="number" placeholder="単価" value="${it.unitPrice}" onchange="items[${i}].unitPrice=Number(this.value);render()" />
+            </div>
+            <input class="full" placeholder="補足（任意）" value="${escapeAttr(it.note || '')}" onchange="items[${i}].note=this.value;render()" />
+            <div class="item-actions"><button onclick="removeItem(${i})">削除</button></div>
+          </div>
+        `
+          )
+          .join('');
+      }
+
+      function escapeHtml(s) {
+        return String(s || '').replace(
+          /[&<>"']/g,
+          (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]
+        );
+      }
+      function escapeAttr(s) {
+        return String(s || '').replace(/"/g, '&quot;');
+      }
+      function yen(n) {
+        return '¥' + Number(n).toLocaleString('ja-JP');
+      }
+
+      function render() {
+        const docNo = document.getElementById('docNo').value || 'KKP-XXXXXXXX-001';
+        const issueDate = document.getElementById('issueDate').value || '';
+        const deliveryDate = document.getElementById('deliveryDate').value || '';
+        const c = {
+          name: document.getElementById('custName').value,
+          postal: document.getElementById('custPostal').value,
+          address: document.getElementById('custAddress').value,
+          phone: document.getElementById('custPhone').value,
+          email: document.getElementById('custEmail').value,
+        };
+        const shipping = Number(document.getElementById('shipping').value || 0);
+        const pay = {
+          method: document.getElementById('payMethod').value,
+          date: document.getElementById('payDate').value,
+          status: document.getElementById('payStatus').value,
+          id: document.getElementById('payId').value,
+        };
+        const subtotal = items.reduce((s, it) => s + it.unitPrice * it.qty, 0);
+        const total = subtotal + shipping;
+
+        document.getElementById('preview').innerHTML = `
+          <div class="header">
+            <div>
+              <h1>納 品 書</h1>
+              <p style="margin-top:6px;font-size:13px;color:#666;">下記の通り納品いたします。</p>
+            </div>
+            <div class="doc-info">
+              <p>納品書番号: ${escapeHtml(docNo)}</p>
+              ${issueDate ? `<p>発行日: ${escapeHtml(issueDate)}</p>` : ''}
+              ${deliveryDate ? `<p>納品日: ${escapeHtml(deliveryDate)}</p>` : ''}
+            </div>
+          </div>
+
+          <div class="section">
+            <h2>お届け先</h2>
+            <table class="info-table">
+              ${c.name ? `<tr><td>お名前</td><td>${escapeHtml(c.name)} 様</td></tr>` : ''}
+              ${c.address ? `<tr><td>ご住所</td><td>${c.postal ? '〒' + escapeHtml(c.postal) + ' ' : ''}${escapeHtml(c.address)}</td></tr>` : ''}
+              ${c.phone ? `<tr><td>お電話</td><td>${escapeHtml(c.phone)}</td></tr>` : ''}
+              ${c.email ? `<tr><td>メール</td><td>${escapeHtml(c.email)}</td></tr>` : ''}
+            </table>
+          </div>
+
+          <div class="section">
+            <h2>ご注文内容</h2>
+            <table class="item-table">
+              <thead>
+                <tr><th>商品名</th><th>数量</th><th class="right">単価（税込）</th><th class="right">金額（税込）</th></tr>
+              </thead>
+              <tbody>
+                ${items
+                  .map(
+                    (it) => `
+                  <tr>
+                    <td>${escapeHtml(it.name)}${it.note ? `<br /><span style="font-size:11px;color:#888;">${escapeHtml(it.note)}</span>` : ''}</td>
+                    <td>${it.qty}</td>
+                    <td class="right">${yen(it.unitPrice)}</td>
+                    <td class="right">${yen(it.unitPrice * it.qty)}</td>
+                  </tr>
+                `
+                  )
+                  .join('')}
+                <tr><td colspan="3" class="right" style="color:#666;">小計</td><td class="right">${yen(subtotal)}</td></tr>
+                <tr><td colspan="3" class="right" style="color:#666;">送料</td><td class="right">${shipping === 0 ? '¥0（送料無料）' : yen(shipping)}</td></tr>
+                <tr class="total-row"><td colspan="3" class="right">合計（税込）</td><td class="right"><span class="total-amount">${yen(total)}</span></td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="section">
+            <h2>お支払い情報</h2>
+            <table class="info-table">
+              <tr><td>決済方法</td><td>${escapeHtml(pay.method)}</td></tr>
+              ${pay.date ? `<tr><td>決済日</td><td>${escapeHtml(pay.date)}</td></tr>` : ''}
+              <tr><td>ステータス</td><td>${escapeHtml(pay.status)}</td></tr>
+              ${pay.id ? `<tr><td>取引ID</td><td style="font-family:monospace;font-size:11px;">${escapeHtml(pay.id)}</td></tr>` : ''}
+            </table>
+          </div>
+
+          <div class="section">
+            <h2>販売者情報</h2>
+            <table class="info-table">
+              <tr><td>屋号</td><td>カムトゥル（Come true）</td></tr>
+              <tr><td>ブランド</td><td>ココペリ シリカウォーター</td></tr>
+              <tr><td>サイト</td><td>https://kokopelli-ec.vercel.app</td></tr>
+              <tr><td>LINE</td><td>https://line.me/R/ti/p/@636yyubo</td></tr>
+            </table>
+          </div>
+
+          <div class="stamp-area"><div class="stamp-box">印</div></div>
+
+          <div class="footer">
+            <p>この納品書はココペリ シリカウォーターの正式な納品書です。</p>
+            <p>ご不明な点がございましたら、LINEまたはメールでお問い合わせください。</p>
+            <p style="margin-top:6px;">ココペリ シリカウォーター | https://kokopelli-ec.vercel.app</p>
+          </div>
+        `;
+      }
+
+      function downloadHTML() {
+        const docNo = document.getElementById('docNo').value || 'nouhinsho';
+        const html = `<!doctype html><html lang="ja"><head><meta charset="utf-8"/><title>納品書 ${docNo}</title><style>
+          body{font-family:'Meiryo','Yu Gothic',sans-serif;color:#333;padding:40px;max-width:800px;margin:0 auto;}
+          .header{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:32px;padding-bottom:16px;border-bottom:3px solid #d97706;}
+          .header h1{font-size:26px;color:#d97706;letter-spacing:0.2em;margin:0;}
+          .doc-info{text-align:right;font-size:12px;color:#666;}
+          .section{margin-bottom:24px;}
+          .section h2{font-size:13px;color:#d97706;margin-bottom:8px;padding-bottom:4px;border-bottom:1px solid #e5e7eb;}
+          table{width:100%;border-collapse:collapse;}
+          .info-table td{padding:5px 0;font-size:13px;}
+          .info-table td:first-child{width:90px;color:#666;font-weight:bold;}
+          .item-table th{background:#fef3c7;padding:8px;text-align:left;font-size:12px;border-bottom:2px solid #d97706;}
+          .item-table td{padding:8px;font-size:13px;border-bottom:1px solid #e5e7eb;}
+          .item-table .right{text-align:right;}
+          .total-row td{font-weight:bold;font-size:15px;border-top:2px solid #333;padding-top:10px;}
+          .total-amount{font-size:22px;color:#d97706;}
+          .footer{margin-top:30px;padding-top:16px;border-top:1px solid #e5e7eb;font-size:11px;color:#999;text-align:center;}
+          .stamp-area{margin-top:24px;display:flex;justify-content:flex-end;}
+          .stamp-box{width:80px;height:80px;border:1px dashed #ccc;display:flex;align-items:center;justify-content:center;color:#ccc;font-size:11px;}
+          @media print{body{padding:20px;}}
+        </style></head><body>${document.getElementById('preview').innerHTML}</body></html>`;
+        const blob = new Blob([html], { type: 'text/html' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${docNo}.html`;
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+
+      function saveJSON() {
+        const data = {
+          docNo: document.getElementById('docNo').value,
+          issueDate: document.getElementById('issueDate').value,
+          deliveryDate: document.getElementById('deliveryDate').value,
+          customer: {
+            name: document.getElementById('custName').value,
+            postal: document.getElementById('custPostal').value,
+            address: document.getElementById('custAddress').value,
+            phone: document.getElementById('custPhone').value,
+            email: document.getElementById('custEmail').value,
+          },
+          items,
+          shipping: Number(document.getElementById('shipping').value || 0),
+          payment: {
+            method: document.getElementById('payMethod').value,
+            date: document.getElementById('payDate').value,
+            status: document.getElementById('payStatus').value,
+            id: document.getElementById('payId').value,
+          },
+        };
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${data.docNo || 'order'}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+
+      function loadJSON() {
+        const inp = document.createElement('input');
+        inp.type = 'file';
+        inp.accept = 'application/json';
+        inp.onchange = (e) => {
+          const f = e.target.files[0];
+          if (!f) return;
+          const r = new FileReader();
+          r.onload = () => {
+            const d = JSON.parse(r.result);
+            document.getElementById('docNo').value = d.docNo || '';
+            document.getElementById('issueDate').value = d.issueDate || '';
+            document.getElementById('deliveryDate').value = d.deliveryDate || '';
+            document.getElementById('custName').value = d.customer?.name || '';
+            document.getElementById('custPostal').value = d.customer?.postal || '';
+            document.getElementById('custAddress').value = d.customer?.address || '';
+            document.getElementById('custPhone').value = d.customer?.phone || '';
+            document.getElementById('custEmail').value = d.customer?.email || '';
+            items = d.items || [];
+            document.getElementById('shipping').value = d.shipping || 0;
+            document.getElementById('payMethod').value =
+              d.payment?.method || 'クレジットカード（Stripe決済）';
+            document.getElementById('payDate').value = d.payment?.date || '';
+            document.getElementById('payStatus').value = d.payment?.status || 'お支払い済み';
+            document.getElementById('payId').value = d.payment?.id || '';
+            renderItems();
+            render();
+          };
+          r.readAsText(f);
+        };
+        inp.click();
+      }
+
+      // 初期化
+      const today = new Date().toISOString().slice(0, 10);
+      const yyyymmdd = today.replaceAll('-', '');
+      document.getElementById('docNo').value = `KKP-${yyyymmdd}-001`;
+      document.getElementById('issueDate').value = today;
+      document.getElementById('payDate').value = today;
+      [
+        'docNo',
+        'issueDate',
+        'deliveryDate',
+        'custName',
+        'custPostal',
+        'custAddress',
+        'custPhone',
+        'custEmail',
+        'shipping',
+        'payMethod',
+        'payDate',
+        'payStatus',
+        'payId',
+      ].forEach((id) => document.getElementById(id).addEventListener('input', render));
+      loadPreset('single');
+    </script>
+  </body>
+</html>

--- a/kokopelli-ec/scripts/nouhinsho/generate.mjs
+++ b/kokopelli-ec/scripts/nouhinsho/generate.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', '..');
+
+const orderPath = process.argv[2] || join(__dirname, 'order.json');
+if (!existsSync(orderPath)) {
+  console.error(`order.json not found: ${orderPath}`);
+  console.error('Usage: node generate.mjs [path/to/order.json]');
+  process.exit(1);
+}
+
+const order = JSON.parse(readFileSync(orderPath, 'utf8'));
+
+const yen = (n) => `¥${Number(n).toLocaleString('ja-JP')}`;
+const subtotal = order.items.reduce((s, it) => s + it.unitPrice * it.qty, 0);
+const shipping = Number(order.shipping ?? 0);
+const total = subtotal + shipping;
+
+const issueDate = order.issueDate || new Date().toISOString().slice(0, 10);
+const yyyymmdd = issueDate.replaceAll('-', '');
+const docNo = order.docNo || `KKP-${yyyymmdd}-001`;
+
+const html = `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>納品書 ${docNo} - ココペリ シリカウォーター</title>
+    <style>
+      @page { size: A4; margin: 10mm 12mm; }
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { font-family: 'Meiryo', 'Yu Gothic', sans-serif; color: #333; font-size: 11px; line-height: 1.4; }
+      .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 14px; padding-bottom: 8px; border-bottom: 2px solid #d97706; }
+      .header h1 { font-size: 20px; color: #d97706; letter-spacing: 0.15em; }
+      .header .lead { margin-top: 4px; font-size: 11px; color: #666; }
+      .header .doc-info { text-align: right; font-size: 10px; color: #666; line-height: 1.6; }
+      .section { margin-bottom: 12px; }
+      .section h2 { font-size: 11px; color: #d97706; margin-bottom: 4px; padding-bottom: 2px; border-bottom: 1px solid #e5e7eb; }
+      table { width: 100%; border-collapse: collapse; }
+      .info-table td { padding: 2px 0; font-size: 11px; }
+      .info-table td:first-child { width: 70px; color: #666; font-weight: bold; }
+      .item-table th { background: #fef3c7; padding: 5px 6px; text-align: left; font-size: 10px; border-bottom: 1.5px solid #d97706; }
+      .item-table td { padding: 5px 6px; font-size: 11px; border-bottom: 1px solid #e5e7eb; }
+      .item-table .right { text-align: right; }
+      .total-row td { font-weight: bold; font-size: 12px; border-top: 1.5px solid #333; padding-top: 6px; }
+      .total-amount { font-size: 16px; color: #d97706; }
+      .footer { margin-top: 12px; padding-top: 6px; border-top: 1px solid #e5e7eb; font-size: 9px; color: #999; text-align: center; line-height: 1.5; }
+      .stamp-area { margin-top: 8px; display: flex; justify-content: flex-end; }
+      .stamp-box { width: 56px; height: 56px; border: 1px dashed #ccc; display: flex; align-items: center; justify-content: center; color: #ccc; font-size: 10px; }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <div>
+        <h1>納 品 書</h1>
+        <p class="lead">下記の通り納品いたします。</p>
+      </div>
+      <div class="doc-info">
+        <p>納品書番号: ${docNo}</p>
+        <p>発行日: ${issueDate}</p>
+        ${order.deliveryDate ? `<p>納品日: ${order.deliveryDate}</p>` : ''}
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>お届け先</h2>
+      <table class="info-table">
+        <tr><td>お名前</td><td>${order.customer.name} 様</td></tr>
+        <tr><td>ご住所</td><td>${order.customer.postal ? `〒${order.customer.postal} ` : ''}${order.customer.address}</td></tr>
+        ${order.customer.phone ? `<tr><td>お電話</td><td>${order.customer.phone}</td></tr>` : ''}
+        ${order.customer.email ? `<tr><td>メール</td><td>${order.customer.email}</td></tr>` : ''}
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>ご注文内容</h2>
+      <table class="item-table">
+        <thead>
+          <tr>
+            <th>商品名</th>
+            <th>数量</th>
+            <th class="right">単価（税込）</th>
+            <th class="right">金額（税込）</th>
+          </tr>
+        </thead>
+        <tbody>
+${order.items
+  .map(
+    (it) => `          <tr>
+            <td>${it.name}${it.note ? `<br /><span style="font-size: 9px; color: #888">${it.note}</span>` : ''}</td>
+            <td>${it.qty}</td>
+            <td class="right">${yen(it.unitPrice)}</td>
+            <td class="right">${yen(it.unitPrice * it.qty)}</td>
+          </tr>`
+  )
+  .join('\n')}
+          <tr>
+            <td colspan="3" class="right" style="color: #666">小計</td>
+            <td class="right">${yen(subtotal)}</td>
+          </tr>
+          <tr>
+            <td colspan="3" class="right" style="color: #666">送料</td>
+            <td class="right">${shipping === 0 ? '¥0（送料無料）' : yen(shipping)}</td>
+          </tr>
+          <tr class="total-row">
+            <td colspan="3" class="right">合計（税込）</td>
+            <td class="right"><span class="total-amount">${yen(total)}</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>お支払い情報</h2>
+      <table class="info-table">
+        <tr><td>決済方法</td><td>${order.payment?.method || 'クレジットカード（Stripe決済）'}</td></tr>
+        <tr><td>決済日</td><td>${order.payment?.date || issueDate}</td></tr>
+        <tr><td>ステータス</td><td>${order.payment?.status || 'お支払い済み'}</td></tr>
+        ${order.payment?.id ? `<tr><td>取引ID</td><td style="font-family: monospace; font-size: 10px;">${order.payment.id}</td></tr>` : ''}
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>販売者情報</h2>
+      <table class="info-table">
+        <tr><td>屋号</td><td>カムトゥル（Come true）</td></tr>
+        <tr><td>ブランド</td><td>ココペリ シリカウォーター</td></tr>
+        <tr><td>サイト</td><td>https://kokopelli-ec.vercel.app</td></tr>
+        <tr><td>LINE</td><td>https://line.me/R/ti/p/@636yyubo</td></tr>
+      </table>
+    </div>
+
+    <div class="stamp-area">
+      <div class="stamp-box">印</div>
+    </div>
+
+    <div class="footer">
+      <p>この納品書はココペリ シリカウォーターの正式な納品書です。</p>
+      <p>ご不明な点がございましたら、LINEまたはメールでお問い合わせください。</p>
+      <p style="margin-top: 8px">ココペリ シリカウォーター | https://kokopelli-ec.vercel.app</p>
+    </div>
+  </body>
+</html>
+`;
+
+const outDir = join(ROOT, 'nouhinsho-output');
+if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+const outPath = join(outDir, `${docNo}.html`);
+writeFileSync(outPath, html, 'utf8');
+
+console.log(`OK: ${outPath}`);
+console.log(`合計: ${yen(total)} (小計 ${yen(subtotal)} + 送料 ${yen(shipping)})`);

--- a/kokopelli-ec/scripts/send-reengagement.mjs
+++ b/kokopelli-ec/scripts/send-reengagement.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * kokopelli-ec 再接客 ワンコマンド送信支援
+ *
+ * 「登録済み・未購入の暖かいリード」を本番Stripeから抽出し、
+ * 各人ぶんの Gmail 作成画面（宛先・件名・本文プリフィル）を自動で開く。
+ * → あとは各ウィンドウで「送信」ボタンを押すだけ。
+ *
+ * ※ Gmail の OAuth スコープに send/compose が無いため「送信」自体は自動化不可。
+ *    本スクリプトは作成画面を全員ぶん開くところまでを全自動化する。
+ *
+ * シークレットキーは一切標準出力に出さない設計。
+ *
+ * 使い方:
+ *   cd C:\Users\timbe\kokopelli-ec
+ *   node scripts/send-reengagement.mjs            // 全期間の未購入会員
+ *   node scripts/send-reengagement.mjs 90         // 直近90日に登録した会員に限定
+ *   node scripts/send-reengagement.mjs 0 --dry    // 開かず一覧だけ確認（--dry）
+ *   KOKO_KEY_VAR=<別名> node scripts/send-reengagement.mjs
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+// ---- キー読み込み（check-live-sales.mjs と同じ安全パターン） ----
+function readUserEnvFromRegistry(name) {
+  if (process.platform !== 'win32') return null;
+  try {
+    const out = execFileSync('reg.exe', ['query', 'HKCU\\Environment', '/v', name], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const m = out.match(/REG_(?:EXPAND_)?SZ\s+(.+?)\s*$/m);
+    return m ? m[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+const VAR_NAME = process.env.KOKO_KEY_VAR || 'KOKOPELLI_STRIPE_LIVE_KEY';
+const KEY = process.env[VAR_NAME] || readUserEnvFromRegistry(VAR_NAME);
+if (!KEY) {
+  console.error(`❌ ${VAR_NAME} が未設定です（User env / HKCU\\Environment 両方）。`);
+  console.error('   別名で登録済みなら: KOKO_KEY_VAR=<変数名> node scripts/send-reengagement.mjs');
+  process.exit(1);
+}
+if (!/^(sk|rk)_live_/.test(KEY)) {
+  console.error(`❌ ${VAR_NAME} は本番キー (sk_live_ / rk_live_) ではありません。`);
+  process.exit(1);
+}
+console.log(`🔑 使用キー変数: ${VAR_NAME}（値は非表示）`);
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry');
+const days = Number(args[0]) > 0 ? Number(args[0]) : 0;
+const sinceSec = days > 0 ? Math.floor(Date.now() / 1000) - days * 86400 : 0;
+const MAX_OPEN = 25; // 一度に開きすぎ防止の安全上限
+const OPEN_DELAY_MS = 1200; // ウィンドウ連続起動の間隔
+
+async function stripeGet(path, params = {}) {
+  const url = new URL('https://api.stripe.com/v1/' + path);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  const res = await fetch(url, { headers: { Authorization: 'Bearer ' + KEY } });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Stripe ${path} ${res.status}: ${body.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+async function pageAll(path, params) {
+  const out = [];
+  let starting_after;
+  for (let i = 0; i < 50; i++) {
+    const q = { limit: '100', ...params };
+    if (starting_after) q.starting_after = starting_after;
+    const j = await stripeGet(path, q);
+    out.push(...j.data);
+    if (!j.has_more || j.data.length === 0) break;
+    starting_after = j.data[j.data.length - 1].id;
+  }
+  return out;
+}
+
+// ---- メール文面（薬機法準拠・COMEBACK500 は本番Stripeで active/¥500OFF/無期限を確認済み） ----
+function buildSubject() {
+  return '【ココペリ】ご注文ページURL変更のお知らせ — お詫びに¥500OFFクーポン';
+}
+function buildBody(name) {
+  const namePart = name ? `${name}様` : 'ご登録者様';
+  const tail = name || '';
+  return `${namePart}
+
+このたびはココペリにご登録いただき、誠にありがとうございます。
+
+大切なお詫びとご案内です。サーバー移転に伴いサイトのURLが変わり、これまでのご案内メールに記載していたご注文ページのリンクが開けない状態になっておりました。ご不便をおかけしており、誠に申し訳ございませんでした。
+
+新しいご注文ページはこちらです。現在は問題なくお手続きいただけます。
+
+▼ 新しいご注文ページ（数分でお手続きが完了します）
+https://kokopelli-ec.vercel.app/checkout?plan=set
+
+■ お詫びの気持ちを込めて — ¥500OFFクーポン
+お支払い画面でクーポンコード「COMEBACK500」をご入力いただくと、¥500引きでご購入いただけます（お一人様1回）。
+
+■ ココペリとは
+犬・猫のための動物用栄養補助食品です。
+・水溶性ケイ素を濃縮した国産のシンプル処方（水＋ケイ素・無添加）
+・毎日の水分・ミネラル補給のサポートに、1日1回を目安に与えるだけ
+・シリンジ（針なし）で量を計りやすく、お水やごはんに混ぜてお使いいただけます
+
+■ はじめての方も、安心してお試しいただけます
+・2本セット ¥5,980（税込・送料無料）でスタートできます
+・1本（30ml）¥3,480 からのご購入も承っております
+・30日間全額返金保証：合わないと感じられたら、開封後でも全額ご返金します
+
+ご不明な点は、本メールへのご返信、またはLINE公式（@636yyubo）からお気軽にどうぞ。
+${tail}さまと、大切なご家族の毎日に寄り添えましたら幸いです。
+
+────────────────
+ココペリ｜Come true（カムトゥル）
+https://kokopelli-ec.vercel.app
+お問い合わせ: timberfrost321@gmail.com
+※本メールは、ココペリにご登録いただいた方へお送りしています。今後の配信を希望されない場合は、お手数ですが本メールにご返信ください。
+────────────────`;
+}
+
+function findChrome() {
+  const candidates = [
+    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+  ];
+  return candidates.find((p) => existsSync(p));
+}
+
+function openCompose(chrome, to, name) {
+  const url =
+    'https://mail.google.com/mail/?view=cm&fs=1' +
+    '&to=' +
+    encodeURIComponent(to) +
+    '&su=' +
+    encodeURIComponent(buildSubject()) +
+    '&body=' +
+    encodeURIComponent(buildBody(name));
+  execFileSync(chrome, ['--new-window', url], { stdio: 'ignore' });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+(async () => {
+  try {
+    console.log('\n=== kokopelli-ec 再接客 ワンコマンド送信支援 ===');
+    console.log(days > 0 ? `対象: 直近${days}日に登録した会員` : '対象: 全期間の登録会員');
+    console.log(dryRun ? 'モード: --dry（一覧確認のみ・compose は開かない）\n' : '');
+
+    const charges = await pageAll('charges', {});
+    const paidCustomerIds = new Set(
+      charges
+        .filter((c) => c.paid && c.status === 'succeeded' && !c.refunded && c.customer)
+        .map((c) => c.customer)
+    );
+    const subs = await pageAll('subscriptions', { status: 'all' });
+    const subCustomerIds = new Set(subs.map((s) => s.customer).filter(Boolean));
+    const customers = await pageAll('customers', {});
+
+    const warmLeads = customers
+      .filter((cust) => {
+        if (cust.metadata?.source !== 'kokopelli-ec') return false;
+        if (days > 0 && cust.created < sinceSec) return false;
+        if (paidCustomerIds.has(cust.id)) return false;
+        if (subCustomerIds.has(cust.id)) return false;
+        if (!cust.email) return false; // メール無しは送れない
+        if (/@example\.(com|net|org)$/i.test(cust.email)) return false; // 動作検証用ダミーは除外
+        return true;
+      })
+      .sort((a, b) => b.created - a.created);
+
+    console.log(`★ 登録済み・未購入の暖かいリード（メールあり）: ${warmLeads.length}件\n`);
+    warmLeads.forEach((c, i) => {
+      const d = new Date(c.created * 1000).toISOString().slice(0, 10);
+      console.log(`  ${String(i + 1).padStart(2)}. ${d}  ${c.email}  ${c.name || ''}`);
+    });
+    console.log('');
+
+    if (warmLeads.length === 0) {
+      console.log('（該当なし — 送るべき暖かいリードはいません）\n');
+      return;
+    }
+    if (dryRun) {
+      console.log(
+        '--dry のため compose は開きませんでした。本番は --dry を外して再実行してください。\n'
+      );
+      return;
+    }
+
+    const chrome = findChrome();
+    if (!chrome) {
+      console.error('❌ Chrome が見つかりません。');
+      process.exit(1);
+    }
+
+    const targets = warmLeads.slice(0, MAX_OPEN);
+    if (warmLeads.length > MAX_OPEN) {
+      console.log(
+        `⚠ 安全上限 ${MAX_OPEN}件まで開きます（残り ${warmLeads.length - MAX_OPEN}件は次回）。\n`
+      );
+    }
+    console.log(`📨 ${targets.length}件の Gmail 作成画面を順に開きます…`);
+    for (let i = 0; i < targets.length; i++) {
+      const c = targets[i];
+      openCompose(chrome, c.email, c.name || '');
+      console.log(`   [${i + 1}/${targets.length}] opened: ${c.email}`);
+      if (i < targets.length - 1) await sleep(OPEN_DELAY_MS);
+    }
+    console.log('\n✅ 全ウィンドウを開きました。各画面で「送信」ボタンを押してください。');
+    console.log('   （Gmail の権限上、送信ボタンの自動クリックはできません）\n');
+  } catch (e) {
+    console.error('❌ 失敗:', e.message);
+    process.exit(2);
+  }
+})();

--- a/kokopelli-ec/src/app/login/page.tsx
+++ b/kokopelli-ec/src/app/login/page.tsx
@@ -1,41 +1,47 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
+import { useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
 
 function LoginContent() {
   const searchParams = useSearchParams();
-  const error = searchParams.get("error");
-  const [email, setEmail] = useState("");
+  const error = searchParams.get('error');
+  const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
+  const [notFound, setNotFound] = useState(false);
   const [errorMsg, setErrorMsg] = useState(
-    error === "expired" ? "リンクの有効期限が切れています。再度送信してください。" :
-    error === "invalid" ? "無効なリンクです。再度送信してください。" : ""
+    error === 'expired'
+      ? 'リンクの有効期限が切れています。再度送信してください。'
+      : error === 'invalid'
+        ? '無効なリンクです。再度送信してください。'
+        : ''
   );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    setErrorMsg("");
+    setErrorMsg('');
+    setNotFound(false);
 
     try {
-      const res = await fetch("/api/auth/send-link", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      const res = await fetch('/api/auth/send-link', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: email.trim() }),
       });
       const data = await res.json();
 
       if (!res.ok) {
-        setErrorMsg(data.error || "送信に失敗しました");
+        setErrorMsg(data.error || '送信に失敗しました');
+        setNotFound(res.status === 404);
       } else {
         setSent(true);
       }
     } catch {
-      setErrorMsg("通信エラーが発生しました");
+      setErrorMsg('通信エラーが発生しました');
     } finally {
       setLoading(false);
     }
@@ -48,18 +54,27 @@ function LoginContent() {
         <main className="flex-1 flex items-center justify-center py-20">
           <div className="max-w-md mx-auto px-4 text-center">
             <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
-              <svg className="w-8 h-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              <svg
+                className="w-8 h-8 text-green-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                />
               </svg>
             </div>
-            <h1 className="text-2xl font-black text-blue-950 mb-3">
-              メールを送信しました
-            </h1>
+            <h1 className="text-2xl font-black text-blue-950 mb-3">メールを送信しました</h1>
             <p className="text-gray-600 mb-2">
               <strong>{email}</strong> にログインリンクを送信しました。
             </p>
             <p className="text-sm text-gray-500 mb-8">
-              メールに記載のリンクをタップしてログインしてください。<br />
+              メールに記載のリンクをタップしてログインしてください。
+              <br />
               リンクは15分間有効です。
             </p>
             <button
@@ -81,29 +96,42 @@ function LoginContent() {
         <div className="max-w-md mx-auto px-4">
           <div className="text-center mb-8">
             <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg className="w-8 h-8 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              <svg
+                className="w-8 h-8 text-blue-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                />
               </svg>
             </div>
-            <h1 className="text-2xl font-black text-blue-950 mb-2">
-              マイページにログイン
-            </h1>
-            <p className="text-sm text-gray-500">
-              ご購入時のメールアドレスを入力してください
-            </p>
+            <h1 className="text-2xl font-black text-blue-950 mb-2">マイページにログイン</h1>
+            <p className="text-sm text-gray-500">ご購入時のメールアドレスを入力してください</p>
           </div>
 
           {errorMsg && (
             <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl mb-4 text-sm">
               {errorMsg}
+              {notFound && (
+                <p className="mt-2">
+                  ご購入時と異なるメールアドレスの可能性があります。まだ会員登録がお済みでない方は、
+                  <Link href="/#member" className="font-bold underline">
+                    無料会員登録（¥500OFFクーポン付き）
+                  </Link>
+                  からご登録ください。
+                </p>
+              )}
             </div>
           )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="block text-sm font-bold text-gray-700 mb-1">
-                メールアドレス
-              </label>
+              <label className="block text-sm font-bold text-gray-700 mb-1">メールアドレス</label>
               <input
                 type="email"
                 value={email}
@@ -118,12 +146,20 @@ function LoginContent() {
               disabled={loading || !email}
               className="w-full bg-gradient-to-r from-blue-900 to-blue-600 text-white py-3.5 rounded-full font-bold shadow-lg hover:shadow-xl transition-all disabled:opacity-50"
             >
-              {loading ? "送信中..." : "ログインリンクを送信"}
+              {loading ? '送信中...' : 'ログインリンクを送信'}
             </button>
           </form>
 
           <p className="text-xs text-gray-400 text-center mt-6">
             パスワード不要。メールに届くリンクをタップするだけでログインできます。
+          </p>
+
+          <p className="text-sm text-gray-600 text-center mt-6">
+            はじめての方は
+            <Link href="/#member" className="text-blue-600 font-bold hover:underline">
+              無料会員登録（¥500OFFクーポン付き）
+            </Link>
+            へ
           </p>
 
           <div className="text-center mt-8">
@@ -145,9 +181,7 @@ function Header() {
           <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-blue-900 to-blue-600 flex items-center justify-center text-white font-bold text-lg shadow-lg">
             K
           </div>
-          <span className="font-black text-blue-900 tracking-wide">
-            kokopelli
-          </span>
+          <span className="font-black text-blue-900 tracking-wide">kokopelli</span>
         </Link>
       </div>
     </header>


### PR DESCRIPTION
前セッションで完成・検証済みだがローカルに取り残されていた2コミットを回収するPRです。mainに入れないと次のgit経由デプロイでログイン導線修正が欠落します。

## 内容

### ba106c99 — 再接客メールの死んだkamuturu.jpリンクを一掃（CVRゼロの根因修正）
- `send-reengagement.mjs`: 注文リンクを kokopelli-ec.vercel.app へ変更、URL変更のお詫び文面に刷新、COMEBACK500（¥500OFF・本番Stripeでactive確認済）を明記
- 検証用ダミーアドレス（@example.com）を抽出対象から除外
- 納品書テンプレ・動画生成スクリプトの旧URLも新URLへ置換
- `list-unordered-members.mjs` / `nouhinsho/` / `send-reengagement.mjs` を新規追跡

### d5680a0e — ログイン画面に会員登録導線を追加（未登録メールの行き止まり解消）
- 診断で登録・ログインのサーバー側/UI側は本番で全チェーン正常動作を実測確認済み。「できない」体験の正体は /login から新規登録への導線ゼロというUX欠陥
- 404時のエラーボックスに LP会員登録セクション（/#member）への案内リンクを追加
- フォーム下に常設の「はじめての方は無料会員登録へ」リンクを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)